### PR TITLE
Use boost::regex instead of std::regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(mumsi)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 INCLUDE(FindPkgConfig)
-find_package(Boost COMPONENTS system REQUIRED)
+find_package(Boost COMPONENTS system regex REQUIRED)
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(PJSIP "libpjproject")

--- a/IncomingConnectionValidator.cpp
+++ b/IncomingConnectionValidator.cpp
@@ -13,16 +13,16 @@ sip::IncomingConnectionValidator::IncomingConnectionValidator(std::string validU
     for (auto &uri : separateUris) {
         boost::replace_all(uri, ".", "\\.");
         boost::replace_all(uri, "*", "\\w*");
-        uriRegexVec.push_back(regex(uri));
+        uriRegexVec.push_back(boost::regex(uri));
     }
 }
 
 bool sip::IncomingConnectionValidator::validateUri(std::string uri) {
-    regex addressRegex("[\"\\w ]*<sip:([\\w\\.]+@[\\w\\.]+)>");
+    boost::regex addressRegex("[\"\\w ]*<sip:([\\w\\.]+@[\\w\\.]+)>");
 
-    smatch s;
+    boost::smatch s;
 
-    if (not regex_match(uri, s, addressRegex)) {
+    if (not boost::regex_match(uri, s, addressRegex)) {
         logger.warn("URI has invalid format: %s", uri.c_str());
         return false;
     }
@@ -30,7 +30,7 @@ bool sip::IncomingConnectionValidator::validateUri(std::string uri) {
     string rawAddress = s[1].str();
 
     for (auto &reg : uriRegexVec) {
-        if (regex_match(rawAddress, s, reg)) {
+        if (boost::regex_match(rawAddress, s, reg)) {
             logger.info("URI %s is valid.", rawAddress.c_str());
             return true;
         }

--- a/IncomingConnectionValidator.hpp
+++ b/IncomingConnectionValidator.hpp
@@ -4,7 +4,7 @@
 #include <log4cpp/Category.hh>
 
 #include <string>
-#include <regex>
+#include <boost/regex.hpp>
 
 namespace sip {
     class IncomingConnectionValidator : boost::noncopyable {
@@ -16,6 +16,6 @@ namespace sip {
     private:
         log4cpp::Category &logger;
         std::string validUriExpression;
-        std::vector<std::regex> uriRegexVec;
+        std::vector<boost::regex> uriRegexVec;
     };
 }


### PR DESCRIPTION
std::regex support is not yet available for older GCC versions.
As boost is used anyway, use also the regex component.