### PR TITLE
Lower required CMake Version to 2.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.1)
+cmake_minimum_required(VERSION 2.8.0)
 project(mumsi)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")


### PR DESCRIPTION
There are no CMake 3 features used, so allow building on common
distribution CMake versions by requiring only CMake 2.8.0