### PR TITLE
add minimal version of libpjsua

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ INCLUDE(FindPkgConfig)
 find_package(Boost COMPONENTS system regex REQUIRED)
 find_package(PkgConfig REQUIRED)
 
-pkg_check_modules(PJSIP "libpjproject")
+pkg_check_modules(PJSIP>=2.6 "libpjproject")
 pkg_check_modules(LOG4CPP "log4cpp")
 
 add_definitions(${PJSIP_CFLAGS})


### PR DESCRIPTION
required "pj::Account" was added in v2.6, but on e.g. Debian v2.5.5 is avail only.